### PR TITLE
Add ability to send back to a PR a checkmarx check status from dispatch

### DIFF
--- a/workflow-templates/im-build-dotnet-ci.yml
+++ b/workflow-templates/im-build-dotnet-ci.yml
@@ -525,6 +525,6 @@ jobs:
               client_payload: {
                 "ref": "${{ needs.build-deployment-artifacts.outputs.NEXT_VERSION }}",
                 "actor": "${{ github.actor }}",
-                "pr-sha": addStatusCheck ? context.payload.pull_request.head.sha : undefined,
+                "pr-sha": "${{ (needs.examine-triggers.outputs.IS_PRERELEASE == 'true' && env.GITUB_SHA) || '' }}"
               }
             });

--- a/workflow-templates/im-build-dotnet-ci.yml
+++ b/workflow-templates/im-build-dotnet-ci.yml
@@ -445,7 +445,7 @@ jobs:
   finish-build:
     if: always() && needs.examine-triggers.outputs.CONTINUE_WORKFLOW == 'true'
     needs: # TODO: Update the needs [] list if any jobs were added/removed/renamed
-      [dotnet-build-and-test, jest, build-deployment-artifacts]
+      [examine-triggers, dotnet-build-and-test, jest, build-deployment-artifacts]
     runs-on: ubuntu-latest # Force this to run on github-hosted runner by using a tag that does not exist on self-hosted runners
     steps:
       - uses: im-open/workflow-conclusion@v2.0.2
@@ -516,11 +516,14 @@ jobs:
         with:
           github-token: ${{ secrets.PIPELINE_BOT_PAT }} # This is an org-level secret
           script: |
+            const addStatusCheck = ${{ needs.examine-triggers.outputs.IS_PRERELEASE == 'true' }};
             github.rest.repos.createDispatchEvent({
               owner: context.repo.owner,
               repo: context.repo.repo,
               event_type: 'run_checkmarx',
               client_payload: {
-                ref: "${{ needs.build-deployment-artifacts.outputs.NEXT_VERSION }}"
+                "ref": "${{ needs.build-deployment-artifacts.outputs.NEXT_VERSION }}",
+                "actor": "${{ github.actor }}",
+                "pr-sha": addStatusCheck ? context.payload.pull_request.head.sha : undefined,
               }
             });

--- a/workflow-templates/im-build-dotnet-ci.yml
+++ b/workflow-templates/im-build-dotnet-ci.yml
@@ -510,6 +510,7 @@ jobs:
 
       # TODO: Delete if you have other triggers for checkmarx scans and don't want it kicked off from the CI build
       #       The repository_dispatch event won't work until the checkmarx workflow has been merged to main for the first time.
+      #       If you want to add a PR status check, include the pr-sha property
       - name: Kick off Checkmarx if workflow succeeded
         if: steps.conclusion.outputs.workflow_conclusion == 'success'
         uses: actions/github-script@v5

--- a/workflow-templates/im-build-dotnet-ci.yml
+++ b/workflow-templates/im-build-dotnet-ci.yml
@@ -525,6 +525,6 @@ jobs:
               client_payload: {
                 "ref": "${{ needs.build-deployment-artifacts.outputs.NEXT_VERSION }}",
                 "actor": "${{ github.actor }}",
-                "pr-sha": "${{ (needs.examine-triggers.outputs.IS_PRERELEASE == 'true' && env.GITUB_SHA) || '' }}"
+                "pr-sha": "${{ (needs.examine-triggers.outputs.IS_PRERELEASE == 'true' && env.GITHUB_SHA) || '' }}"
               }
             });

--- a/workflow-templates/im-test-checkmarx-cli-sast-scan.yml
+++ b/workflow-templates/im-test-checkmarx-cli-sast-scan.yml
@@ -21,8 +21,8 @@ on:
   workflow_dispatch:
     inputs:
       branch-tag-sha:
-        description: The branch, tag or sha of the checkmarx scan should be run against.
-        required: true
+        description: The branch, tag or sha of the checkmarx scan should be run against. Leave blank to use workflow branch.
+        required: false
   schedule:
     # See the following site for help creating the right cron syntax: https://crontab.guru/
     # The cron job is specified in UTC.
@@ -31,27 +31,47 @@ on:
     - cron: 5 4 * * 2
   repository_dispatch:
     types: [run_checkmarx]
-    # Expects a client payload like : { ref: value-of-ref}
+    # Expects a client payload like : { ref: value-of-ref, pr-sha: head sha}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.inputs.branch-tag-sha || github.event.client_payload.ref || github.ref }}
+
+env:
+  REFERENCE: ${{ github.event.inputs.branch-tag-sha || github.event.client_payload.ref || github.ref_name }}
+  RUNNER_URL: ${{ GITHUB_SERVER_URL }}/${{ GITHUB_REPOSITORY }}/actions/runs/${{ GITHUB_RUN_ID }}
+  TIMEZONE: 'america/denver' # TODO: Verify timezone
+  
 jobs:
   scan-the-code:
     runs-on: [self-hosted, ubuntu-20.04]
     steps:
-      - name: Checkout main for Schedule Trigger
-        uses: actions/checkout@v2
-        if: github.event_name == 'schedule'
-
-      - name: Checkout Provided Ref for Repository Dispatch Trigger
-        uses: actions/checkout@v2
-        if: github.event_name == 'repository_dispatch'
+      - name: Checkout Repository
+        uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.client_payload.ref }}
-
-      - name: Checkout provided branch/tag/sha for Workflow Dispatch Trigger
-        uses: actions/checkout@v2
-        if: github.event_name == 'workflow_dispatch'
+          ref: ${{ env.REFERENCE }}
+          
+      - name: Add status check to PR
+        if: github.event.client_payload.pr-sha != 0
+        id: create-check
+        uses: actions/github-script@v6
         with:
-          ref: ${{ github.event.inputs.branch-tag-sha }}
+          script: |
+            const { owner, repo } = context.repo;                     
+            const response = await github.rest.checks.create({
+              owner,
+              repo,
+              head_sha: '${{ github.event.client_payload.pr-sha }}', 
+              name: 'status check - checkmarx',
+              status: 'in_progress',
+              details_url: '${{ env.RUNNER_URL }}',
+              external_id: context.runId.toString(),
+              output: {
+                title: 'Checkmarx SAST Scan',
+                summary: 'Pending',
+                text: '${{ env.RUNNER_URL }}'
+              }
+            });
+            return response.data.id;
 
       - name: Run the Scan
         id: scan
@@ -88,3 +108,37 @@ jobs:
         with:
           name: Checkmarx Report
           path: ${{ steps.scan.outputs.report-path }}
+          
+      - name: Complete status check on PR
+        if: always() && steps.create-check.outcome == 'success'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { owner, repo } = context.repo;            
+            await github.rest.checks.update({
+              owner: owner,
+              repo: repo,
+              check_run_id: '${{ steps.create-check.outputs.result }}', 
+              completed_at: new Date().toISOString(),
+              status: 'completed',
+              conclusion: '${{ (steps.scan.outcome == 'success' && 'success') || 'action_required' }}',
+              output: {
+                title: 'Checkmarx SAST Scan',
+                summary: 'This security scan completed.',
+                text: `See [PDF Report](${{ env.RUNNER_URL }}) for results.`,
+              }
+            });
+          
+      - name: Send Status to Teams
+        if: failure() && github.event.client_payload.pr-sha == 0 && secrets.MS_TEAMS_URI != 0
+        uses: im-open/post-status-to-teams-action@v1.1.2
+        with:
+          title: Checkmarx Security Analysis
+          workflow-status: ${{ steps.conclusion.outputs.workflow_conclusion }}
+          workflow-type: Deploy
+          teams-uri: ${{ secrets.MS_TEAMS_URI }} # This is a repo-level secret (unless 'environment:' has been added to this job)
+          timezone: ${{ env.TIMEZONE }}
+          custom-facts: |
+            [
+              { "name": "Actor", "value": "${{ github.event.client_payload.actor || github.actor }}" }
+            ]

--- a/workflow-templates/im-test-checkmarx-cli-sast-scan.yml
+++ b/workflow-templates/im-test-checkmarx-cli-sast-scan.yml
@@ -38,7 +38,7 @@ concurrency:
 
 env:
   REFERENCE: ${{ github.event.inputs.branch-tag-sha || github.event.client_payload.ref || github.ref_name }}
-  RUNNER_URL: ${{ GITHUB_SERVER_URL }}/${{ GITHUB_REPOSITORY }}/actions/runs/${{ GITHUB_RUN_ID }}
+  RUNNER_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
   TIMEZONE: 'america/denver' # TODO: Verify timezone
   
 jobs:


### PR DESCRIPTION
It still makes sense to perform Checkmarx check separate from the the build itself.  That way it builds don't take forever.  Since Checkmarx is also provides false positives, it is helpful not to block the PR from being merged.

However, it is still helpful to inform the team when and where it fails.  Either through a team notification or a PR check status.